### PR TITLE
feat: add preventProcessEnvWrite option to enhance security

### DIFF
--- a/.changeset/beige-paths-sit.md
+++ b/.changeset/beige-paths-sit.md
@@ -1,5 +1,48 @@
 ---
-'node-env-resolver': patch
+'node-env-resolver': minor
 ---
 
-Added poller
+## Security Hardening for Reference-First Deployments
+
+New helpers to enforce strict source policies and prevent secret leakage:
+
+### New Features
+
+- **`strictReferencePolicies(options)`** — Policy preset that:
+  - Blocks dotenv in production by default
+  - Enforces source restrictions on sensitive keys
+  - Accepts resolver name prefixes (e.g., `aws-secrets` matches `aws-secrets(prod/app)`)
+
+- **`strictReferenceResolveOptions(options)`** — Complete resolve options preset with:
+  - Audit logging enabled
+  - Strict policies applied
+  - Sensible secure defaults
+
+- **`preventProcessEnvWrite`** option (default: `true`) — Keeps resolved values out of `process.env` to prevent accidental secret exposure
+
+### Improvements
+
+- `enforceAllowedSources` now checks `resolvedVia` from reference handlers, enabling strict source locks for pointer-in-env workflows
+- Better error messages showing actual source path when enforcement fails
+
+### Migration Example
+
+```ts
+// Before: Manual policy configuration
+const config = await resolveAsync({
+  resolvers: [[processEnv(), { API_KEY: string() }]],
+  options: {
+    policies: { allowDotenvInProduction: false },
+    enableAudit: true,
+  },
+});
+
+// After: Secure-by-default preset
+const config = await resolveAsync({
+  resolvers: [[processEnv(), { API_KEY: string() }]],
+  options: strictReferenceResolveOptions({
+    sensitiveKeys: ['API_KEY'],
+    secretSources: ['aws-secrets'],
+  }),
+});
+```

--- a/packages/node-env-resolver/README.md
+++ b/packages/node-env-resolver/README.md
@@ -1577,6 +1577,7 @@ interface ResolveOptions {
   policies?: PolicyOptions; // Security policies (default: undefined)
   enableAudit?: boolean; // Audit logging (default: auto in production)
   secretsDir?: string; // Base directory for file secrets (Docker/K8s)
+  preventProcessEnvWrite?: boolean; // Keep resolved values out of process.env (default: true)
 }
 
 interface PolicyOptions {
@@ -1822,6 +1823,56 @@ interface PolicyOptions {
   enforceAllowedSources?: Record<string, string[]>;
 }
 ```
+
+### Reference-first hardening preset
+
+For incident response hardening, keep secret *values* out of Vercel env vars.
+Store references such as `aws-sm://prod/stripe-key` and resolve the value at
+runtime via reference handlers.
+
+```ts
+import { resolveAsync, strictReferenceResolveOptions } from 'node-env-resolver';
+import { processEnv } from 'node-env-resolver/resolvers';
+import { string } from 'node-env-resolver/validators';
+import { createAwsSecretHandler } from 'node-env-resolver-aws';
+
+const config = await resolveAsync({
+  resolvers: [[processEnv(), { STRIPE_KEY: string() }]],
+  references: {
+    handlers: {
+      'aws-sm': createAwsSecretHandler({ region: 'us-east-1' }),
+    },
+  },
+  options: strictReferenceResolveOptions({
+    sensitiveKeys: ['STRIPE_KEY'],
+    secretSources: ['aws-secrets'],
+  }),
+});
+```
+
+What this enforces:
+
+- `allowDotenvInProduction: false` (secure default)
+- `enforceAllowedSources` for sensitive keys (prevents accidental fallback)
+- `enableAudit: true` for source reconstruction via `getAuditLog()`
+
+If you only want policies (not full resolve options), use:
+
+```ts
+import { strictReferencePolicies } from 'node-env-resolver';
+
+const policies = strictReferencePolicies({
+  sensitiveKeys: ['STRIPE_KEY', 'DATABASE_URL'],
+  secretSources: ['aws-secrets'],
+});
+```
+
+Note on `process.env` mutation:
+
+- `resolve()` / `resolveAsync()` keep resolved values out of `process.env` by default (`preventProcessEnvWrite: true`).
+- Resolved values live in the returned typed config object unless your app
+  explicitly re-exports or assigns them.
+- If you explicitly set `preventProcessEnvWrite: false`, primitive resolved values are written to `process.env`.
 
 ## Audit Logging
 

--- a/packages/node-env-resolver/src/index.test.ts
+++ b/packages/node-env-resolver/src/index.test.ts
@@ -297,6 +297,57 @@ describe('Simplified resolve() API', () => {
   });
 });
 
+describe('preventProcessEnvWrite option', () => {
+  it('does not write resolved values to process.env by default', async () => {
+    delete process.env.NER_WRITE_TEST;
+
+    const config = await resolveAsync({
+      resolvers: [[mockProvider({ NER_WRITE_TEST: 'resolved-value' }), { NER_WRITE_TEST: string() }]],
+    });
+
+    expect(config.NER_WRITE_TEST).toBe('resolved-value');
+    expect(process.env.NER_WRITE_TEST).toBeUndefined();
+  });
+
+  it('writes resolved primitive values to process.env when explicitly disabled', async () => {
+    delete process.env.NER_WRITE_TEST;
+    delete process.env.NER_WRITE_NUM;
+    delete process.env.NER_WRITE_BOOL;
+
+    const config = await resolveAsync({
+      resolvers: [
+        [
+          mockProvider({
+            NER_WRITE_TEST: 'resolved-value',
+            NER_WRITE_NUM: '8080',
+            NER_WRITE_BOOL: 'true',
+          }),
+          {
+            NER_WRITE_TEST: string(),
+            NER_WRITE_NUM: number(),
+            NER_WRITE_BOOL: boolean(),
+          },
+        ],
+      ],
+      options: {
+        preventProcessEnvWrite: false,
+      },
+    });
+
+    expect(config.NER_WRITE_TEST).toBe('resolved-value');
+    expect(config.NER_WRITE_NUM).toBe(8080);
+    expect(config.NER_WRITE_BOOL).toBe(true);
+
+    expect(process.env.NER_WRITE_TEST).toBe('resolved-value');
+    expect(process.env.NER_WRITE_NUM).toBe('8080');
+    expect(process.env.NER_WRITE_BOOL).toBe('true');
+
+    delete process.env.NER_WRITE_TEST;
+    delete process.env.NER_WRITE_NUM;
+    delete process.env.NER_WRITE_BOOL;
+  });
+});
+
 describe('Zod and Standard Schema helpers', () => {
   it('works with Zod-like schema', async () => {
     const schema = {

--- a/packages/node-env-resolver/src/index.ts
+++ b/packages/node-env-resolver/src/index.ts
@@ -92,6 +92,12 @@ import {
   resolveEnvInternalSync,
 } from './resolver';
 import { processEnv } from './process-env';
+export {
+  strictReferencePolicies,
+  strictReferenceResolveOptions,
+  type StrictReferencePoliciesOptions,
+  type StrictReferenceResolveOptions,
+} from './security';
 
 /**
  * Helper to build default resolvers (just processEnv)
@@ -169,6 +175,27 @@ function mergeReferences(
     ...options,
     references,
   };
+}
+
+function writeResolvedToProcessEnv(
+  resolved: Record<string, unknown>,
+): void {
+  for (const [key, value] of Object.entries(resolved)) {
+    if (value === undefined || value === null) continue;
+
+    if (typeof value === 'string') {
+      process.env[key] = value;
+      continue;
+    }
+
+    if (
+      typeof value === 'number' ||
+      typeof value === 'boolean' ||
+      typeof value === 'bigint'
+    ) {
+      process.env[key] = String(value);
+    }
+  }
 }
 
 // Function overloads for resolve
@@ -272,6 +299,7 @@ function resolve(arg1: unknown, arg2?: unknown): unknown {
     interpolate: true,
     strict: true,
     enableAudit: isProduction,
+    preventProcessEnvWrite: true,
     policies: defaultPolicies,
     ...options,
   };
@@ -282,6 +310,10 @@ function resolve(arg1: unknown, arg2?: unknown): unknown {
     resolvers,
     resolveOptions,
   );
+
+  if (resolveOptions.preventProcessEnvWrite === false) {
+    writeResolvedToProcessEnv(result as Record<string, unknown>);
+  }
 
   return result as unknown;
 }
@@ -381,6 +413,7 @@ async function resolveAsync(config: ResolveAsyncConfig): Promise<unknown> {
     interpolate: true,
     strict: true,
     enableAudit: isProduction,
+    preventProcessEnvWrite: true,
     policies: defaultPolicies,
     ...normalizedOptions,
   };
@@ -391,6 +424,11 @@ async function resolveAsync(config: ResolveAsyncConfig): Promise<unknown> {
     resolvers,
     resolveOptions,
   );
+
+  if (resolveOptions.preventProcessEnvWrite === false) {
+    writeResolvedToProcessEnv(result as Record<string, unknown>);
+  }
+
   return result as unknown;
 }
 
@@ -485,6 +523,7 @@ function safeResolve<T extends SimpleEnvSchema>(
       interpolate: true,
       strict: true,
       enableAudit: isProduction,
+      preventProcessEnvWrite: true,
       policies: defaultPolicies,
       ...options,
     };
@@ -496,6 +535,11 @@ function safeResolve<T extends SimpleEnvSchema>(
       resolvers,
       resolveOptions,
     );
+
+    if (resolveOptions.preventProcessEnvWrite === false) {
+      writeResolvedToProcessEnv(result as Record<string, unknown>);
+    }
+
     return {
       success: true,
       data: result as { [K in keyof T]: InferSimpleValue<T[K]> },
@@ -589,6 +633,7 @@ async function safeResolveAsync(config: ResolveAsyncConfig): Promise<unknown> {
     interpolate: true,
     strict: true,
     enableAudit: isProduction,
+    preventProcessEnvWrite: true,
     policies: defaultPolicies,
     ...normalizedOptions,
   };
@@ -600,6 +645,11 @@ async function safeResolveAsync(config: ResolveAsyncConfig): Promise<unknown> {
       resolvers,
       resolveOptions,
     );
+
+    if (resolveOptions.preventProcessEnvWrite === false) {
+      writeResolvedToProcessEnv(result as Record<string, unknown>);
+    }
+
     return { success: true, data: result } as unknown;
   } catch (error) {
     return {

--- a/packages/node-env-resolver/src/resolver.ts
+++ b/packages/node-env-resolver/src/resolver.ts
@@ -416,8 +416,30 @@ function applyPolicies(
 
   if (enforceAllowedSources && enforceAllowedSources[key] && provenanceForKey) {
     const allowed = enforceAllowedSources[key];
-    if (!allowed.includes(provenanceForKey.source)) {
-      return `${key} must be sourced from one of: ${allowed.join(', ')} (actual: ${provenanceForKey.source})`;
+    const sourceCandidates = new Set<string>();
+
+    const addSourceCandidate = (source: string | undefined) => {
+      if (!source) return;
+      sourceCandidates.add(source);
+
+      // Allow generic source aliases (e.g. "aws-secrets" to match
+      // resolver names like "aws-secrets(prod/app)").
+      const paren = source.indexOf('(');
+      if (paren > 0) {
+        sourceCandidates.add(source.slice(0, paren));
+      }
+    };
+
+    addSourceCandidate(provenanceForKey.source);
+    addSourceCandidate(provenanceForKey.resolvedVia);
+
+    const isAllowed = allowed.some((entry) => sourceCandidates.has(entry));
+
+    if (!isAllowed) {
+      const actual = provenanceForKey.resolvedVia
+        ? `${provenanceForKey.source} via ${provenanceForKey.resolvedVia}`
+        : provenanceForKey.source;
+      return `${key} must be sourced from one of: ${allowed.join(', ')} (actual: ${actual})`;
     }
   }
 

--- a/packages/node-env-resolver/src/security.test.ts
+++ b/packages/node-env-resolver/src/security.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from 'vitest';
+import {
+  strictReferencePolicies,
+  strictReferenceResolveOptions,
+  resolveAsync,
+  type AsyncResolver,
+} from './index';
+import { string } from './validators';
+
+describe('strictReferencePolicies', () => {
+  it('creates source-lock policies for sensitive keys with secure defaults', () => {
+    const policies = strictReferencePolicies({
+      sensitiveKeys: ['STRIPE_KEY', 'DATABASE_URL'],
+    });
+
+    expect(policies.allowDotenvInProduction).toBe(false);
+    expect(policies.enforceAllowedSources).toEqual({
+      STRIPE_KEY: ['aws-secrets'],
+      DATABASE_URL: ['aws-secrets'],
+    });
+  });
+
+  it('merges with base policy and supports multiple allowed sources', () => {
+    const policies = strictReferencePolicies({
+      sensitiveKeys: ['STRIPE_KEY'],
+      secretSources: ['aws-secrets', 'vault'],
+      basePolicies: {
+        enforceAllowedSources: {
+          PORT: ['process.env'],
+        },
+      },
+    });
+
+    expect(policies.enforceAllowedSources).toEqual({
+      PORT: ['process.env'],
+      STRIPE_KEY: ['aws-secrets', 'vault'],
+    });
+  });
+
+  it('overwrites existing enforceAllowedSources entries for explicit sensitive keys', () => {
+    const policies = strictReferencePolicies({
+      sensitiveKeys: ['STRIPE_KEY'],
+      secretSources: ['aws-secrets'],
+      basePolicies: {
+        enforceAllowedSources: {
+          STRIPE_KEY: ['vault'],
+        },
+      },
+    });
+
+    expect(policies.enforceAllowedSources).toEqual({
+      STRIPE_KEY: ['aws-secrets'],
+    });
+  });
+});
+
+describe('strictReferenceResolveOptions', () => {
+  it('builds resolve options with audit enabled by default', () => {
+    const options = strictReferenceResolveOptions({
+      sensitiveKeys: ['STRIPE_KEY'],
+    });
+
+    expect(options.enableAudit).toBe(true);
+    expect(options.policies).toEqual({
+      allowDotenvInProduction: false,
+      enforceAllowedSources: {
+        STRIPE_KEY: ['aws-secrets'],
+      },
+    });
+  });
+
+  it('enforces source lock at runtime', async () => {
+    const resolver: AsyncResolver = {
+      name: 'process.env',
+      async load() {
+        return { STRIPE_KEY: 'mock_secret_value_for_testing_12345' };
+      },
+    };
+
+    await expect(
+        resolveAsync({
+          resolvers: [[resolver, { STRIPE_KEY: string() }]],
+          options: strictReferenceResolveOptions({
+            sensitiveKeys: ['STRIPE_KEY'],
+            secretSources: ['aws-secrets'],
+          }),
+      }),
+    ).rejects.toThrow(/must be sourced from one of: aws-secrets/);
+  });
+
+  it('accepts resolver names that include source metadata suffix', async () => {
+    const resolver: AsyncResolver = {
+      name: 'aws-secrets(prod/app)',
+      async load() {
+        return { STRIPE_KEY: 'mock_secret_value_for_testing_12345' };
+      },
+    };
+
+    const config = await resolveAsync({
+      resolvers: [[resolver, { STRIPE_KEY: string() }]],
+      options: strictReferenceResolveOptions({
+        sensitiveKeys: ['STRIPE_KEY'],
+      }),
+    });
+
+    expect(config.STRIPE_KEY).toBe('mock_secret_value_for_testing_12345');
+  });
+
+  it('accepts pointer-in-env values when reference handler resolves via allowed source', async () => {
+    const resolver: AsyncResolver = {
+      name: 'process.env',
+      async load() {
+        return { STRIPE_KEY: 'aws-sm://prod/stripe-key' };
+      },
+    };
+
+    const config = await resolveAsync({
+      resolvers: [[resolver, { STRIPE_KEY: string() }]],
+      references: {
+        handlers: {
+          'aws-sm': {
+            name: 'aws-sm',
+            async resolve() {
+              return {
+                value: 'mock_secret_value_for_testing_12345',
+                resolvedVia: 'aws-secrets',
+              };
+            },
+          },
+        },
+      },
+      options: strictReferenceResolveOptions({
+        sensitiveKeys: ['STRIPE_KEY'],
+      }),
+    });
+
+    expect(config.STRIPE_KEY).toBe('mock_secret_value_for_testing_12345');
+  });
+
+  it('rejects pointer-in-env values when resolvedVia is not in allowed sources', async () => {
+    const resolver: AsyncResolver = {
+      name: 'process.env',
+      async load() {
+        return { STRIPE_KEY: 'aws-sm://prod/stripe-key' };
+      },
+    };
+
+    await expect(
+      resolveAsync({
+        resolvers: [[resolver, { STRIPE_KEY: string() }]],
+        references: {
+          handlers: {
+            'aws-sm': {
+              name: 'aws-sm',
+              async resolve() {
+                return {
+                  value: 'mock_secret_value_for_testing_12345',
+                  resolvedVia: 'vault',
+                };
+              },
+            },
+          },
+        },
+        options: strictReferenceResolveOptions({
+          sensitiveKeys: ['STRIPE_KEY'],
+          secretSources: ['aws-secrets'],
+        }),
+      }),
+    ).rejects.toThrow(/must be sourced from one of: aws-secrets/);
+  });
+});

--- a/packages/node-env-resolver/src/security.ts
+++ b/packages/node-env-resolver/src/security.ts
@@ -1,0 +1,103 @@
+import type { PolicyOptions, ResolveOptions } from './types.js';
+
+export interface StrictReferencePoliciesOptions {
+  /**
+   * Variables that must come from secret managers (not dotenv/process.env fallbacks).
+   * Example: ['STRIPE_KEY', 'DATABASE_URL']
+   */
+  sensitiveKeys: readonly string[];
+  /**
+   * Allowed resolver source(s) for sensitive keys.
+   * Matching accepts:
+   * - exact resolver/source name
+   * - source prefix before `(` (e.g. `aws-secrets(prod/app)` -> `aws-secrets`)
+   * - reference handler `resolvedVia` value
+   * Default: ['aws-secrets']
+   */
+  secretSources?: readonly string[] | string;
+  /**
+   * Keep secure default in production: false blocks dotenv values.
+   * You can pass a whitelist array to allow specific non-secret vars from dotenv.
+   * Default: false
+   */
+  allowDotenvInProduction?: PolicyOptions['allowDotenvInProduction'];
+  /**
+   * Optional base policy object to merge into.
+   */
+  basePolicies?: PolicyOptions;
+}
+
+/**
+ * Build a strict production policy preset for reference-first deployments:
+ * - Blocks dotenv in production by default
+ * - Forces sensitive keys to come from reference-backed resolvers (e.g. aws-secrets)
+ */
+export function strictReferencePolicies(
+  options: StrictReferencePoliciesOptions,
+): PolicyOptions {
+  const {
+    sensitiveKeys,
+    secretSources = ['aws-secrets'],
+    allowDotenvInProduction = false,
+    basePolicies = {},
+  } = options;
+
+  const allowedSources = Array.isArray(secretSources)
+    ? [...secretSources]
+    : [secretSources];
+
+  const enforceAllowedSources: Record<string, string[]> = {
+    ...(basePolicies.enforceAllowedSources ?? {}),
+  };
+
+  for (const key of sensitiveKeys) {
+    enforceAllowedSources[key] = allowedSources;
+  }
+
+  return {
+    ...basePolicies,
+    allowDotenvInProduction,
+    enforceAllowedSources,
+  };
+}
+
+export interface StrictReferenceResolveOptions
+  extends Omit<StrictReferencePoliciesOptions, 'basePolicies'> {
+  /**
+   * Optional extra resolve options to merge with this preset.
+   */
+  baseOptions?: Partial<ResolveOptions>;
+  /**
+   * Audit should be enabled for incident response reconstruction.
+   * Default: true
+   */
+  enableAudit?: boolean;
+}
+
+/**
+ * Resolve options preset for strict reference-first hardening.
+ */
+export function strictReferenceResolveOptions(
+  options: StrictReferenceResolveOptions,
+): Partial<ResolveOptions> {
+  const {
+    baseOptions = {},
+    sensitiveKeys,
+    secretSources,
+    allowDotenvInProduction,
+    enableAudit = true,
+  } = options;
+
+  const basePolicies = baseOptions.policies ?? {};
+
+  return {
+    ...baseOptions,
+    enableAudit,
+    policies: strictReferencePolicies({
+      sensitiveKeys,
+      secretSources,
+      allowDotenvInProduction,
+      basePolicies,
+    }),
+  };
+}

--- a/packages/node-env-resolver/src/types.ts
+++ b/packages/node-env-resolver/src/types.ts
@@ -116,6 +116,13 @@ export interface ResolveOptions {
   strict?: boolean;
   policies?: Record<string, unknown>;
   enableAudit?: boolean;
+  /**
+   * Prevent writing resolved values back into process.env.
+   * Default: true (secure-by-default)
+   *
+   * Set to false only if you explicitly need legacy write-back behavior.
+   */
+  preventProcessEnvWrite?: boolean;
   /** Debug view options for safe inspection */
   debug?: import('./debug.js').DebugOptions;
   /** Optional secret/reference dereferencing */


### PR DESCRIPTION
- Introduced `preventProcessEnvWrite` option to control whether resolved values are written to `process.env`, defaulting to true for secure behavior.
- Updated README to document the new option and its implications for secret management.
- Added tests to verify the functionality of the new option, ensuring resolved values remain outside of `process.env` unless explicitly allowed.
- Enhanced policy enforcement for source validation in the resolver to improve security.