### PR TITLE
chore: sync package versions with published registry state

### DIFF
--- a/packages/nextjs-resolver/package.json
+++ b/packages/nextjs-resolver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-env-resolver-nextjs",
-  "version": "7.4.1",
+  "version": "7.4.3",
   "description": "Zero-config Next.js integration for node-env-resolver with client/server split and App Router support",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/node-env-resolver-aws/package.json
+++ b/packages/node-env-resolver-aws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-env-resolver-aws",
-  "version": "12.0.0",
+  "version": "12.0.2",
   "description": "AWS resolvers for node-env-resolver (Secrets Manager, SSM Parameter Store)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/node-env-resolver-dotenvx/package.json
+++ b/packages/node-env-resolver-dotenvx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-env-resolver-dotenvx",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "description": "Dotenvx and OS Keychain resolvers for node-env-resolver (encrypted .env files, keychain:// secret references)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/node-env-resolver/package.json
+++ b/packages/node-env-resolver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-env-resolver",
-  "version": "6.5.0",
+  "version": "6.5.2",
   "description": "Type-safe environment variable resolver with async resolvers - lightweight, tree-shakeable, no dependencies",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/vite-resolver/package.json
+++ b/packages/vite-resolver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-env-resolver-vite",
-  "version": "2.4.1",
+  "version": "2.4.3",
   "description": "Zero-config Vite integration for node-env-resolver with client/server split",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Syncs each published package's `version` field on `main` up to the version currently published on npm.

**Why:** during the GitLab-interim period, supersede/clean versions were published to npm, but those version bumps never landed on GitHub `main`. As a result `main` is *behind* the registry, so the next `changesets` release would recompute versions that are **already published** → publish collisions. This realigns `main` with the registry so releases compute correctly.

**Scope:** only the `version` field of published (non-private) packages is changed — **no dependency, source, or changeset changes**. Dependency updates already merged on GitHub (e.g. dependabot) are preserved. Internal deps use the `workspace:` protocol, so no internal-dep rewrites are needed.

Validated by CI (`build-and-test` runs the frozen install).
